### PR TITLE
Allow handlers that are not callables

### DIFF
--- a/src/Container/MessageBusFactory.php
+++ b/src/Container/MessageBusFactory.php
@@ -56,6 +56,7 @@ class MessageBusFactory
         $middlewares       = $config['messenger']['buses'][$this->name]['middleware'] ?? [];
         $routes            = $config['messenger']['buses'][$this->name]['routes'] ?? [];
         $allowsNoHandler   = $config['messenger']['buses'][$this->name]['allows_no_handler'] ?? false;
+        $methodName        = $config['messenger']['buses'][$this->name]['method_name'] ?? '__invoke';
 
         $stack = [];
         // Add default logging middleware
@@ -77,7 +78,7 @@ class MessageBusFactory
 
         // Add default message handling middleware
         if ($defaultMiddleware === true) {
-            $stack[] = new MessageHandlingMiddleware($container, $handlers, $allowsNoHandler);
+            $stack[] = new MessageHandlingMiddleware($container, $handlers, $allowsNoHandler, $methodName);
         }
 
         if (empty($stack)) {

--- a/src/Middleware/MessageHandlingMiddleware.php
+++ b/src/Middleware/MessageHandlingMiddleware.php
@@ -25,11 +25,19 @@ class MessageHandlingMiddleware implements MiddlewareInterface
     /** @var bool */
     private $allowsNoHandler;
 
-    public function __construct(ContainerInterface $handlerResolver, array $messageHandlers, bool $allowsNoHandler)
-    {
+    /** @var string */
+    private $methodName;
+
+    public function __construct(
+        ContainerInterface $handlerResolver,
+        array $messageHandlers,
+        bool $allowsNoHandler,
+        string $methodName
+    )  {
         $this->handlerResolver = $handlerResolver;
         $this->messageHandlers = $messageHandlers;
         $this->allowsNoHandler = $allowsNoHandler;
+        $this->methodName = $methodName;
     }
 
     /**
@@ -52,7 +60,7 @@ class MessageHandlingMiddleware implements MiddlewareInterface
 
         if (! is_array($this->messageHandlers[$messageClass])) {
             $handler = $this->handlerResolver->get($this->messageHandlers[$messageClass]);
-            $result  = $handler($message);
+            $result  = $handler->{$this->methodName}($message);
 
             $stack->next()->handle($envelope, $stack);
 


### PR DESCRIPTION
It's useful to allow handlers that are not callables.

This is the most simple way to do this, but maybe you got a better idea?