### PR TITLE
fix: allow future versions of the event-dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.1",
         "psr/container": "^1.0",
-        "symfony/event-dispatcher": "4.4",
+        "symfony/event-dispatcher": "^4.4",
         "symfony/messenger": "^4.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1df2394edd7f141d6ae1236c639bb4b1",
+    "content-hash": "9c4027008190f988a65e4f956ee3bba1",
     "packages": [
         {
             "name": "psr/cache",
@@ -227,16 +227,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.4.0",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "ab1c43e17fff802bef0a898f3bc088ac33b8e0e1"
+                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ab1c43e17fff802bef0a898f3bc088ac33b8e0e1",
-                "reference": "ab1c43e17fff802bef0a898f3bc088ac33b8e0e1",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b3c3068a72623287550fe20b84a2b01dcba2686f",
+                "reference": "b3c3068a72623287550fe20b84a2b01dcba2686f",
                 "shasum": ""
             },
             "require": {
@@ -293,7 +293,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-08T22:40:51+00:00"
+            "time": "2019-11-28T13:33:56+00:00"
         },
         {
             "name": "symfony/messenger",
@@ -2494,33 +2494,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
+                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
+                "reference": "d638ebbb58daba25a6a0dc7969e1358a0e3c6682",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -2553,7 +2553,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-10-03T11:07:50+00:00"
+            "time": "2019-12-17T16:54:23+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/test/EventBusTest.php
+++ b/test/EventBusTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Xtreamwayz\Expressive\Messenger\ConfigProvider;
 use XtreamwayzTest\Expressive\Messenger\Fixtures\DummyEvent;
 use XtreamwayzTest\Expressive\Messenger\Fixtures\DummyEventHandler;
-use XtreamwayzTest\Expressive\Messenger\Fixtures\DummyQueryHandler;
+use XtreamwayzTest\Expressive\Messenger\Fixtures\DummyEventHandlerTwo;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 use function array_replace_recursive;
@@ -82,15 +82,15 @@ class EventBusTest extends TestCase
 
         $eventHandler1 = $this->prophesize(DummyEventHandler::class);
         $eventHandler1->__invoke($event)->shouldBeCalledTimes(1);
-        $eventHandler2 = $this->prophesize(DummyEventHandler::class);
+        $eventHandler2 = $this->prophesize(DummyEventHandlerTwo::class);
         $eventHandler2->__invoke($event)->shouldBeCalledTimes(1);
 
-        $this->config['dependencies']['services'][DummyEventHandler::class] = $eventHandler1->reveal();
-        $this->config['dependencies']['services'][DummyQueryHandler::class] = $eventHandler2->reveal();
+        $this->config['dependencies']['services'][DummyEventHandler::class]    = $eventHandler1->reveal();
+        $this->config['dependencies']['services'][DummyEventHandlerTwo::class] = $eventHandler2->reveal();
 
         $this->config['messenger']['buses']['messenger.event.bus']['handlers'][DummyEvent::class] = [
             DummyEventHandler::class,
-            DummyQueryHandler::class,
+            DummyEventHandlerTwo::class,
         ];
 
         /** @var MessageBus $eventBus */

--- a/test/Fixtures/DummyEventHandlerTwo.php
+++ b/test/Fixtures/DummyEventHandlerTwo.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace XtreamwayzTest\Expressive\Messenger\Fixtures;
+
+class DummyEventHandlerTwo
+{
+    public function __invoke(DummyEvent $event) : void
+    {
+    }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://www.conventionalcommits.org/
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] fix: Bugfix
- [ ] feat: Feature
- [ ] revert: Revert previous commit
- [ ] style: Code style update (formatting, local variables)
- [ ] refactor: Refactoring (no functional changes, no api changes)
- [ ] ci: CI related changes
- [ ] build: Build related changes
- [ ] docs: Documentation content changes
- [ ] perf: A code change that improves performance
- [x] test: Adding missing tests or correcting existing tests

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The symfony event-dispatcher is locked to version 4.4.

Issue Number: N/A

## What is the new behavior?

Allow event-dispatcher `^4.4`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->



## Other information
