### PR TITLE
fix: change default serializer configuration

### DIFF
--- a/example/full-cqrs-config.php
+++ b/example/full-cqrs-config.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App;
 
-use Symfony\Component\Mailer\Messenger\MessageHandler;
 use Symfony\Component\Mailer\Messenger\SendEmailMessage;
 
 return [

--- a/example/serializer-config.php
+++ b/example/serializer-config.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Xtreamwayz\PsrContainerMessenger\Serializer\SymfonySerializerFactory;
+
+return [
+    // phpcs:disable
+    'dependencies' => [
+        'aliases' => [
+            'messenger.serializer' => Serializer::class,
+        ],
+        'factories' => [
+            Serializer::class => SymfonySerializerFactory::class,
+        ]
+    ],
+
+    'messenger' => [
+        'serializer' => [
+            'default_serializer' => null,
+            'symfony_serializer' => [
+                'format' => 'json',
+                'context' => [],
+            ],
+        ],
+        'default_bus' => 'messenger.command.bus',
+        'buses'       => [
+            'messenger.command.bus' => [
+                'allows_no_handler' => false,
+                'handlers'          => [],
+                'middleware'        => [
+                    'messenger.command.middleware.add_bus_stamp',
+                    'messenger.command.middleware.handler',
+                ],
+                'routes'            => [],
+            ],
+            'messenger.event.bus'   => [
+                'allows_no_handler' => true,
+                'handlers'          => [],
+                'middleware'        => [
+                    'messenger.event.middleware.handler',
+                ],
+                'routes'            => [],
+            ],
+            'messenger.query.bus'   => [
+                'allows_no_handler' => false,
+                'handlers'          => [],
+                'middleware'        => [
+                    'messenger.query.middleware.handler',
+                ],
+                'routes'            => [],
+            ],
+        ],
+    ],
+    // phpcs:enable
+];

--- a/example/single-bus-config.php
+++ b/example/single-bus-config.php
@@ -11,6 +11,12 @@ use Xtreamwayz\PsrContainerMessenger\Container\SendMessageMiddlewareFactory;
 return [
     // phpcs:disable
     'dependencies' => [
+        'aliases' => [
+            'messenger.serializer' => PhpSerializer::class,
+        ],
+        'invokables' => [
+            PhpSerializer::class,
+        ],
         'factories' => [
             'messenger.default.bus'                => [MessageBusFactory::class, 'default'],
             'messenger.default.middleware.handler' => [HandleMessageMiddlewareFactory::class, 'default'],

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,7 +6,6 @@ namespace Xtreamwayz\PsrContainerMessenger;
 
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
-use Symfony\Component\Messenger\Transport\Serialization\Serializer as SymfonySerializer;
 use Xtreamwayz\PsrContainerMessenger\Container\AddBusNameStampMiddlewareFactory;
 use Xtreamwayz\PsrContainerMessenger\Container\HandleMessageMiddlewareFactory;
 use Xtreamwayz\PsrContainerMessenger\Container\MessageBusFactory;
@@ -31,7 +30,7 @@ class ConfigProvider
                 'messenger.serializer' => PhpSerializer::class,
             ],
             'invokables' => [
-                PhpSerializer::class => PhpSerializer::class,
+                PhpSerializer::class,
             ],
             'factories' => [
                 ConsumeMessagesCommand::class => Command\ConsumeMessagesCommandFactory::class,
@@ -49,8 +48,6 @@ class ConfigProvider
                 'messenger.query.middleware.sender'  => [SendMessageMiddlewareFactory::class, 'messenger.query.bus'],
 
                 'messenger.command.middleware.add_bus_stamp' => [AddBusNameStampMiddlewareFactory::class, 'messenger.command.bus'],
-
-                SymfonySerializer::class => Serializer\SymfonySerializerFactory::class,
             ],
         ];
         // phpcs:enable
@@ -78,13 +75,6 @@ class ConfigProvider
                     'handlers'          => [],
                     'middleware'        => [],
                     'routes'            => [],
-                ],
-            ],
-            'serializer' => [
-                'default_serializer' => null,
-                'symfony_serializer' => [
-                    'format' => 'json',
-                    'context' => [],
                 ],
             ],
         ];

--- a/test/Integration/AuraDiTest.php
+++ b/test/Integration/AuraDiTest.php
@@ -44,8 +44,8 @@ class AuraDiTest extends TestCase
             $this->assertContainerHasService($container, $name, $factory);
         }
 
-        foreach ($config['dependencies']['invokables'] as $name => $factory) {
-            $this->assertContainerHasService($container, $name, $factory);
+        foreach ($config['dependencies']['invokables'] as $name) {
+            $this->assertContainerHasService($container, $name, $name);
         }
 
         foreach ($config['dependencies']['factories'] as $name => $factory) {

--- a/test/Integration/LaminasServiceManagerTest.php
+++ b/test/Integration/LaminasServiceManagerTest.php
@@ -46,8 +46,8 @@ class LaminasServiceManagerTest extends TestCase
             $this->assertContainerHasService($container, $name, $factory);
         }
 
-        foreach ($config['dependencies']['invokables'] as $name => $factory) {
-            $this->assertContainerHasService($container, $name, $factory);
+        foreach ($config['dependencies']['invokables'] as $name) {
+            $this->assertContainerHasService($container, $name, $name);
         }
 
         foreach ($config['dependencies']['factories'] as $name => $factory) {

--- a/test/Integration/PimpleTest.php
+++ b/test/Integration/PimpleTest.php
@@ -44,8 +44,8 @@ class PimpleTest extends TestCase
             $this->assertContainerHasService($container, $name, $factory);
         }
 
-        foreach ($config['dependencies']['invokables'] as $name => $factory) {
-            $this->assertContainerHasService($container, $name, $factory);
+        foreach ($config['dependencies']['invokables'] as $name) {
+            $this->assertContainerHasService($container, $name, $name);
         }
 
         foreach ($config['dependencies']['factories'] as $name => $factory) {

--- a/test/Serializer/SymfonySerializerFactoryTest.php
+++ b/test/Serializer/SymfonySerializerFactoryTest.php
@@ -18,7 +18,7 @@ class SymfonySerializerFactoryTest extends TestCase
 
     public function setUp(): void
     {
-        $this->config = array_replace_recursive((new ConfigProvider())(), require 'example/basic-config.php');
+        $this->config = array_replace_recursive((new ConfigProvider())(), require 'example/serializer-config.php');
     }
 
     private function getContainer(): ServiceManager
@@ -32,8 +32,6 @@ class SymfonySerializerFactoryTest extends TestCase
 
     public function testSymfonySerializerIsLoaded(): void
     {
-        $this->config['dependencies']['aliases']['messenger.serializer'] = Serializer::class;
-
         $serializer = $this->getContainer()->get('messenger.serializer');
 
         $this->assertInstanceOf(Serializer::class, $serializer);


### PR DESCRIPTION
- fix the default PhpSerializer invokable config
- move the default Symfony Serializer config from the ConfigProvider
- fix tests for invokables as they have no factory

The default Symfony Serializer config in the ConfigProvider caused issue when testing the container for valid values and the component is not part of the project.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://www.conventionalcommits.org/
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `[x]`. -->

- [ ] build: Changes that affect the build system or external dependencies
- [ ] ci: Changes to our CI configuration files and scripts
- [ ] docs: Documentation content changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that neither fixes a bug nor adds a feature
- [ ] style: Changes that do not affect the meaning of the code
- [x] test: Adding missing tests or correcting existing tests
- [ ] revert: Revert previous commit

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior. -->

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
